### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/minidetector/__init__.py
+++ b/minidetector/__init__.py
@@ -47,7 +47,7 @@ def detect_mobile(view):
     def detected(request, *args, **kwargs):
         Middleware.process_request(request)
         return view(request, *args, **kwargs)
-    detected.__doc__ = "%s\n[Wrapped by detect_mobile which detects if the request is from a phone]" % view.__doc__
+    detected.__doc__ = "{0!s}\n[Wrapped by detect_mobile which detects if the request is from a phone]".format(view.__doc__)
     return detected
 
 

--- a/minidetector/tests.py
+++ b/minidetector/tests.py
@@ -38,10 +38,10 @@ def MobileDetectionFactory(uas, expected):
             minidetector.Middleware.process_request(request)
             if self.expected:
                 self.assert_(request.mobile,
-                             "Mobile Not Detected: %s" % ua)
+                             "Mobile Not Detected: {0!s}".format(ua))
             else:
                 self.assert_(not request.mobile,
-                             "Mobile Falsely Detected: %s" % ua)
+                             "Mobile Falsely Detected: {0!s}".format(ua))
 
     def testnum(num):
         def test(self):
@@ -52,8 +52,8 @@ def MobileDetectionFactory(uas, expected):
     suite = TestSuite()
     for x in range(len(uas)):
         if not uas[x].startswith('#'):
-            setattr(MobileDetection, 'test%s' % x, testnum(x))
-            suite.addTest(MobileDetection('test%s' % x))
+            setattr(MobileDetection, 'test{0!s}'.format(x), testnum(x))
+            suite.addTest(MobileDetection('test{0!s}'.format(x)))
     return suite
 
 

--- a/treeio/account/ajax.py
+++ b/treeio/account/ajax.py
@@ -168,7 +168,7 @@ def attachment(request, object_id, update_id=None):
                                              response_format='html')
 
             dajax.add_data(
-                {'target': 'div.attachment-block[object="%s"]' % object_id, 'content': object_markup}, 'treeio.add_data')
+                {'target': 'div.attachment-block[object="{0!s}"]'.format(object_id), 'content': object_markup}, 'treeio.add_data')
 
         if update_id:
             attachments = Attachment.objects.filter(
@@ -181,7 +181,7 @@ def attachment(request, object_id, update_id=None):
                                                  request),
                                              response_format='html')
             dajax.add_data(
-                {'target': 'div.attachment-record-block[object="%s"]' % update_id, 'content': update_markup}, 'treeio.add_data')
+                {'target': 'div.attachment-record-block[object="{0!s}"]'.format(update_id), 'content': update_markup}, 'treeio.add_data')
 
     except Exception:
         pass
@@ -259,8 +259,8 @@ def easy_invite(request, emails=None):
                                      context_instance=RequestContext(request),
                                      response_format='html')
 
-    dajax.add_data({'target': "div.easy-invite[emails='%s']" %
-                   (emails_original), 'content': invite_markup}, 'treeio.add_data')
+    dajax.add_data({'target': "div.easy-invite[emails='{0!s}']".format(
+                   (emails_original)), 'content': invite_markup}, 'treeio.add_data')
     return dajax.json()
 
 dajaxice_functions.register(easy_invite)

--- a/treeio/account/cron.py
+++ b/treeio/account/cron.py
@@ -31,21 +31,19 @@ class CronNotifier(object):
             if current_url != record.url:
                 current_url = record.url
                 message_html.write(
-                    u'<br /><br />\n\n<a href="%s">' % unicode(record.url))
+                    u'<br /><br />\n\n<a href="{0!s}">'.format(unicode(record.url)))
                 if record.sender:
-                    message_html.write(u'%s</a> (%s):<br />\n' %
-                                       (unicode(record.sender), unicode(record.sender.get_human_type())))
+                    message_html.write(u'{0!s}</a> ({1!s}):<br />\n'.format(unicode(record.sender), unicode(record.sender.get_human_type())))
                 else:
                     message_html.write(
-                        u'%s</a>:<br />\n' % unicode(record.url))
+                        u'{0!s}</a>:<br />\n'.format(unicode(record.url)))
                 message_html.write('-' * 30)
                 message_html.write('<br /><br />\n\n')
-            message_html.write(u'%s:<br />\n%s - %s<br /><br />\n\n' %
-                               (unicode(record.author), unicode(record.date_created.isoformat()),
+            message_html.write(u'{0!s}:<br />\n{1!s} - {2!s}<br /><br />\n\n'.format(unicode(record.author), unicode(record.date_created.isoformat()),
                                 record.get_full_message()))
         signature = "This is an automated message from Tree.io service (http://tree.io). Please do not reply to this e-mail."
-        subject = "%s summary of [Tree.io] %s" % (
-            note.get_ntype_display(), unicode(note.owner),)
+        subject = "{0!s} summary of [Tree.io] {1!s}".format(
+            note.get_ntype_display(), unicode(note.owner))
 
         # send email notification to recipient
         try:

--- a/treeio/account/models.py
+++ b/treeio/account/models.py
@@ -31,7 +31,7 @@ class NotificationSetting(models.Model):
 
     def __unicode__(self):
         if self.module:
-            return '%s of %s' % (self.get_ntype_display(), self.module.title)
+            return '{0!s} of {1!s}'.format(self.get_ntype_display(), self.module.title)
         return self.get_ntype_display()
 
     def save(self, *args, **kwargs):
@@ -60,6 +60,6 @@ class NotificationSetting(models.Model):
         if self.ntype == 'd':
             return '<h1>Today</h1>'
         elif self.ntype == 'w':
-            return '<h1>%s week</h1>' % self.next_date.isocalendar()[1]
+            return '<h1>{0!s} week</h1>'.format(self.next_date.isocalendar()[1])
         elif self.ntype == 'm':
-            return '<h1>%s</h1>' % calendar.month_name[self.next_date.month]
+            return '<h1>{0!s}</h1>'.format(calendar.month_name[self.next_date.month])

--- a/treeio/core/ajax/converter.py
+++ b/treeio/core/ajax/converter.py
@@ -41,7 +41,7 @@ class MultiHiddenWidget(MultiWidget):
         # in self.widgets.
         if not isinstance(value, list):
             value = self.decompress(value)
-        output = [u'<span id="%s_%s">' % (u'multi', name)]
+        output = [u'<span id="{0!s}_{1!s}">'.format(u'multi', name)]
         final_attrs = self.build_attrs(attrs)
         id_ = final_attrs.get('id', None)
         for i, widget in enumerate(self.widgets):

--- a/treeio/core/api/auth/store/__init__.py
+++ b/treeio/core/api/auth/store/__init__.py
@@ -171,13 +171,13 @@ def get_store(path='treeio.core.api.auth.store.db.ModelStore'):
         store_class = getattr(importlib.import_module(module), attr)
     except ValueError:
         raise ImproperlyConfigured(
-            'Invalid piston oauth store string: "%s"' % path)
+            'Invalid piston oauth store string: "{0!s}"'.format(path))
     except ImportError, e:
         raise ImproperlyConfigured(
-            'Error loading piston oauth store module "%s": "%s"' % (module, e))
+            'Error loading piston oauth store module "{0!s}": "{1!s}"'.format(module, e))
     except AttributeError:
         raise ImproperlyConfigured(
-            'Module "%s" does not define a piston oauth store named "%s"' % (module, attr))
+            'Module "{0!s}" does not define a piston oauth store named "{1!s}"'.format(module, attr))
 
     return store_class()
 

--- a/treeio/core/api/auth/utils.py
+++ b/treeio/core/api/auth/utils.py
@@ -56,7 +56,7 @@ def require_params(oauth_request, parameters=None):
         param for param in params if not oauth_request or param not in oauth_request)
     if missing:
         response = HttpResponse(
-            'Missing OAuth parameters: %s' % (', '.join(missing)))
+            'Missing OAuth parameters: {0!s}'.format((', '.join(missing))))
         response.status_code = 401
         return response
 

--- a/treeio/core/api/auth/views.py
+++ b/treeio/core/api/auth/views.py
@@ -64,7 +64,7 @@ def authorize_request_token(request, form_class=AuthorizeRequestTokenForm, templ
                 request, oauth_request, request_token)
             if request_token.callback is not None and request_token.callback != 'oob':
                 domain = RequestSite(request).domain
-                return HttpResponseRedirect('%s&%s' % (
+                return HttpResponseRedirect('{0!s}&{1!s}'.format(
                     request_token.get_callback_url(), urlencode({'oauth_token': request_token.key, 'domain': domain})))
             else:
                 return render_to_response(verification_template_name,

--- a/treeio/core/api/doc.py
+++ b/treeio/core/api/doc.py
@@ -34,7 +34,7 @@ def generate_doc(handler_cls):
     """
     if not (type(handler_cls) is ObjectHandlerMetaClass
             or type(handler_cls) is handler.HandlerMetaClass):
-        raise ValueError("Give me handler, not %s" % type(handler_cls))
+        raise ValueError("Give me handler, not {0!s}".format(type(handler_cls)))
 
     return HandlerDocumentation(handler_cls)
 
@@ -73,7 +73,7 @@ class HandlerMethod(object):
             spec += argn
 
             if argdef:
-                spec += '=%s' % argdef
+                spec += '={0!s}'.format(argdef)
 
             spec += ', '
 
@@ -136,15 +136,15 @@ class HandlerMethod(object):
     name = property(get_name)
 
     def __repr__(self):
-        return "<Method: %s>" % self.name
+        return "<Method: {0!s}>".format(self.name)
 
 
 def _convert(template, params=None):
     """URI template converter"""
     if params is None:
         params = []
-    paths = template % dict([p, "{%s}" % p] for p in params)
-    return u'/api%s%s' % (get_script_prefix(), paths)
+    paths = template % dict([p, "{{{0!s}}}".format(p)] for p in params)
+    return u'/api{0!s}{1!s}'.format(get_script_prefix(), paths)
 
 
 class HandlerDocumentation(object):
@@ -262,7 +262,7 @@ class HandlerDocumentation(object):
     resource_uri_template = property(get_resource_uri_template)
 
     def __repr__(self):
-        return u'<Documentation for "%s">' % self.name
+        return u'<Documentation for "{0!s}">'.format(self.name)
 
 
 def documentation_view(request, module):

--- a/treeio/core/api/models.py
+++ b/treeio/core/api/models.py
@@ -33,7 +33,7 @@ class Nonce(models.Model):
     key = models.CharField(max_length=255)
 
     def __unicode__(self):
-        return u"Nonce %s for %s" % (self.key, self.consumer_key)
+        return u"Nonce {0!s} for {1!s}".format(self.key, self.consumer_key)
 
 
 class Consumer(models.Model):
@@ -50,7 +50,7 @@ class Consumer(models.Model):
     objects = ConsumerManager()
 
     def __unicode__(self):
-        return u"Consumer %s with key %s" % (self.name, self.key)
+        return u"Consumer {0!s} with key {1!s}".format(self.name, self.key)
 
     def generate_random_codes(self):
         """
@@ -96,7 +96,7 @@ class Token(models.Model):
     objects = TokenManager()
 
     def __unicode__(self):
-        return u"%s Token %s for %s" % (self.get_token_type_display(), self.key, self.consumer_id)
+        return u"{0!s} Token {1!s} for {2!s}".format(self.get_token_type_display(), self.key, self.consumer_id)
 
     def to_string(self, only_key=False):
         token_dict = {
@@ -132,9 +132,9 @@ class Token(models.Model):
             parts = urlparse.urlparse(self.callback)
             scheme, netloc, path, params, query, fragment = parts[:6]
             if query:
-                query = '%s&oauth_verifier=%s' % (query, self.verifier)
+                query = '{0!s}&oauth_verifier={1!s}'.format(query, self.verifier)
             else:
-                query = 'oauth_verifier=%s' % self.verifier
+                query = 'oauth_verifier={0!s}'.format(self.verifier)
             return urlparse.urlunparse((scheme, netloc, path, params,
                                         query, fragment))
         return self.callback

--- a/treeio/core/api/utils.py
+++ b/treeio/core/api/utils.py
@@ -17,8 +17,7 @@ def get_version():
 
 
 def format_error(error):
-    return u"Piston/%s (Django %s) crash report:\n\n%s" % \
-        (get_version(), django_version(), error)
+    return u"Piston/{0!s} (Django {1!s}) crash report:\n\n{2!s}".format(get_version(), django_version(), error)
 
 
 class rc_factory(object):
@@ -106,7 +105,7 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             that `throttle_extra` might be set on the request
             object. If so, append the identifier name with it.
             """
-            ident += ':%s' % str(request.throttle_extra)
+            ident += ':{0!s}'.format(str(request.throttle_extra))
 
         if ident:
             """
@@ -115,7 +114,7 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             can't use it yet. If someone sees this after it's in
             stable, you can change it here.
             """
-            ident += ':%s' % extra
+            ident += ':{0!s}'.format(extra)
 
             now = time.time()
             count, expiration = cache.get(ident, (1, None))
@@ -126,7 +125,7 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             if count >= max_requests and expiration > now:
                 t = rc.THROTTLED
                 wait = int(expiration - now)
-                t.content = 'Throttled, wait %d seconds.' % wait
+                t.content = 'Throttled, wait {0:d} seconds.'.format(wait)
                 t['Retry-After'] = wait
                 return t
 
@@ -301,7 +300,7 @@ def send_consumer_mail(consumer):
     try:
         subject = settings.PISTON_OAUTH_EMAIL_SUBJECTS[consumer.status]
     except AttributeError:
-        subject = "Your API Consumer for %s " % Site.objects.get_current().name
+        subject = "Your API Consumer for {0!s} ".format(Site.objects.get_current().name)
         if consumer.status == "accepted":
             subject += "was accepted!"
         elif consumer.status == "canceled":
@@ -311,7 +310,7 @@ def send_consumer_mail(consumer):
         else:
             subject += "is awaiting approval."
 
-    template = "piston/mails/consumer_%s.txt" % consumer.status
+    template = "piston/mails/consumer_{0!s}.txt".format(consumer.status)
 
     try:
         body = loader.render_to_string(template,
@@ -336,6 +335,6 @@ def send_consumer_mail(consumer):
         mail_admins(_(subject), body, fail_silently=True)
 
     if settings.DEBUG and consumer.user:
-        print "Mail being sent, to=%s" % consumer.user.email
-        print "Subject: %s" % _(subject)
+        print "Mail being sent, to={0!s}".format(consumer.user.email)
+        print "Subject: {0!s}".format(_(subject))
         print body

--- a/treeio/core/db/db.py
+++ b/treeio/core/db/db.py
@@ -62,7 +62,7 @@ class DatabaseDict(UserDict.DictMixin, dict):
                 try:
                     if NO_DEFAULT:
                         raise DatabaseNotFound(
-                            'No database found for %s' % key)
+                            'No database found for {0!s}'.format(key))
                     return self.store['default']
                 except KeyError:
                     raise RuntimeError(

--- a/treeio/core/forms.py
+++ b/treeio/core/forms.py
@@ -322,7 +322,7 @@ class SqlSettingsForm(forms.Form):
 
     def clean_sql_engine(self):
         engine = self.cleaned_data['sql_engine']
-        return "django.db.backends.%s" % engine
+        return "django.db.backends.{0!s}".format(engine)
 
     def create_database(self):
         if not self._errors:
@@ -346,7 +346,7 @@ class SqlSettingsForm(forms.Form):
             except Exception as exc:
                 del connections._connections['treeio_new_db']
                 raise ValidationError(
-                    _("Can't create database. SQL error is") + ' %s' % exc)
+                    _("Can't create database. SQL error is") + ' {0!s}'.format(exc))
             finally:
                 del settings.DATABASES['treeio_new_db']
 

--- a/treeio/core/mail.py
+++ b/treeio/core/mail.py
@@ -130,15 +130,15 @@ class BaseEmail(Thread):
                 from django.core.mail import mail_admins
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 domain = getattr(settings, 'CURRENT_DOMAIN', 'default')
-                subject = "Exception for %s: %s %s" % (
+                subject = "Exception for {0!s}: {1!s} {2!s}".format(
                     domain, unicode(exc_type), unicode(exc_value))
                 body = subject + "\n\n"
                 body += unicode(core.__file__) + "\n\n"
-                body += u"Server: %s\n\n" % self.server
-                body += u"Port: %s\n\n" % unicode(self.port)
-                body += u"Username: %s\n\n" % self.username
-                body += u"From: %s\n\n" % self.fromaddr
-                body += u"To: %s\n\n" % self.toaddr
+                body += u"Server: {0!s}\n\n".format(self.server)
+                body += u"Port: {0!s}\n\n".format(unicode(self.port))
+                body += u"Username: {0!s}\n\n".format(self.username)
+                body += u"From: {0!s}\n\n".format(self.fromaddr)
+                body += u"To: {0!s}\n\n".format(self.toaddr)
                 for s in traceback.format_tb(exc_traceback):
                     body += s + '\n'
                 mail_admins(subject, body)
@@ -173,13 +173,13 @@ class EmailInvitation(SystemEmail):
         self.sender = sender
         self.domain = domain
 
-        subject = '%s has invited you to Tree.io' % (self.sender)
+        subject = '{0!s} has invited you to Tree.io'.format((self.sender))
 
         toaddr = self.invitation.email
 
         signature = """
 \r\n
-- %s""" % unicode(self.sender)
+- {0!s}""".format(unicode(self.sender))
 
         body = """
 Hi!
@@ -190,8 +190,8 @@ Tree.io is a new online service that helps you manage your business online.
 \r\n
 Use this link to join me:
 \r\n
-http://%s/accounts/invitation/?email=%s&key=%s
-        """ % (unicode(self.domain),
+http://{0!s}/accounts/invitation/?email={1!s}&key={2!s}
+        """.format(unicode(self.domain),
                unicode(self.invitation.email),
                unicode(self.invitation.key))
 
@@ -211,8 +211,8 @@ Hello!
 \r\n
 You have requested a password reset for your Tree.io account.
 \r\n
-New password for: %s\r\n\r\n Password: %s\r\n\r\n
-""" % (username, password)
+New password for: {0!s}\r\n\r\n Password: {1!s}\r\n\r\n
+""".format(username, password)
 
         super(EmailPassword, self).__init__(toaddr, subject, body)
 

--- a/treeio/core/management/commands/installdb.py
+++ b/treeio/core/management/commands/installdb.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         if dbengine in ('mysql', 'postgresql', 'postgresql_psycopg2', 'oracle', 'sqlite3'):
             dbengine = 'django.db.backends.' + dbengine
         else:
-            raise CommandError('Unknown database engine: %s' % dbengine)
+            raise CommandError('Unknown database engine: {0!s}'.format(dbengine))
 
         if dbengine.endswith('sqlite3'):
             dbname = raw_input(

--- a/treeio/core/management/commands/runcron.py
+++ b/treeio/core/management/commands/runcron.py
@@ -170,9 +170,9 @@ class CronRunner():
                     while len(self.queue) > 0 and len(self.pool) < self.poolsize:
                         cron = self.queue.pop()
                         self.pool.append(cron)
-                        if 'hardtree_%s_last' % (cron.database) in cache:
+                        if 'hardtree_{0!s}_last'.format((cron.database)) in cache:
                             last_accessed = cache.get(
-                                'hardtree_%s_last' % (cron.database))
+                                'hardtree_{0!s}_last'.format((cron.database)))
                             if last_accessed > (time.time() - int(self.qualify_high)):
                                 cron.priority = self.priority_high
                                 cronlogger.debug(

--- a/treeio/core/middleware/chat.py
+++ b/treeio/core/middleware/chat.py
@@ -21,7 +21,7 @@ def get_key(postfix=""):
     :type postfix: basestring
     """
     domain = getattr(settings, 'CURRENT_DOMAIN', 'default')
-    key = "treeio_%s_chat_%s" % (domain, postfix)
+    key = "treeio_{0!s}_chat_{1!s}".format(domain, postfix)
     return key
 
 

--- a/treeio/core/middleware/user.py
+++ b/treeio/core/middleware/user.py
@@ -41,7 +41,7 @@ class CommonMiddleware(object):
         if hasattr(request, 'user') and request.user.is_authenticated():
 
             domain = getattr(settings, 'CURRENT_DOMAIN', 'default')
-            cache.set('treeio_%s_last' % (domain), time.time())
+            cache.set('treeio_{0!s}_last'.format((domain)), time.time())
             if settings.ANAF_SUBSCRIPTION_BLOCKED and '/accounts' not in request.path:
                 return HttpResponseRedirect('/accounts/logout')
 

--- a/treeio/core/models.py
+++ b/treeio/core/models.py
@@ -707,7 +707,7 @@ class Object(models.Model):
                 if kwargs['updated']:
                     updated_text = ""
                     for obj in kwargs['updated']:
-                        updated_text += '<a href="%s" class="popup-link">%s</a>' % (
+                        updated_text += '<a href="{0!s}" class="popup-link">{1!s}</a>'.format(
                             obj.get_absolute_url(), unicode(obj))
                         if kwargs['updated'].index(obj) < len(kwargs['updated']) - 1:
                             updated_text += ', '
@@ -846,7 +846,7 @@ class Object(models.Model):
         if isinstance(user, django_auth.User):
             user = user.profile
         elif not isinstance(user, User):
-            raise ValueError('user argument should be either a django_auth.User or treeio.core.User object got %s' % type(user))
+            raise ValueError('user argument should be either a django_auth.User or treeio.core.User object got {0!s}'.format(type(user)))
 
         # get default permissions from settings
         try:
@@ -989,10 +989,10 @@ class Object(models.Model):
         if hasattr(value, 'all'):
             # Returns value for ManyToMany fields
             value = value.all()
-        if hasattr(self, 'get_%s_display' % field_name):
+        if hasattr(self, 'get_{0!s}_display'.format(field_name)):
             # Handle choices to ChoiceFields
             try:
-                value = getattr(self, 'get_%s_display' % field_name)()
+                value = getattr(self, 'get_{0!s}_display'.format(field_name))()
             except:
                 pass
         return value
@@ -1147,18 +1147,16 @@ class UpdateRecord(models.Model):
         if author:
             # E-mail contents for e-mail notifications
             full_message = self.get_full_message()
-            html = '%s:<br /><br />\n\n<a href="%s">%s</a> (%s):<br /><br />\n\n%s<br /><br />\n\n' % \
-                (unicode(author), obj.get_absolute_url(), unicode(obj),
+            html = '{0!s}:<br /><br />\n\n<a href="{1!s}">{2!s}</a> ({3!s}):<br /><br />\n\n{4!s}<br /><br />\n\n'.format(unicode(author), obj.get_absolute_url(), unicode(obj),
                  unicode(obj.get_human_type()), full_message)
-            grittertext = '%s:<br />\n\n<a href="#%s">%s</a> (%s):<br />\n\n%s<br />\n\n' % \
-                (unicode(author), obj.get_absolute_url(), unicode(obj),
+            grittertext = '{0!s}:<br />\n\n<a href="#{1!s}">{2!s}</a> ({3!s}):<br />\n\n{4!s}<br />\n\n'.format(unicode(author), obj.get_absolute_url(), unicode(obj),
                  unicode(obj.get_human_type()), full_message)
             if 'request' in kwargs:
                 domain = RequestSite(kwargs['request']).domain
                 html = html.replace('href="', 'href="http://' + domain)
             body = strip_tags(html)
             signature = "This is an automated message from Tree.io service (http://tree.io). Please do not reply to this e-mail."
-            subject = "[Tree.io%s] %s: %s - %s" % (' #%d' % obj.id if self.record_type != 'delete' else '', unicode(author),
+            subject = "[Tree.io{0!s}] {1!s}: {2!s} - {3!s}".format(' #{0:d}'.format(obj.id) if self.record_type != 'delete' else '', unicode(author),
                                                    unicode(obj.get_human_type()), unicode(strip_tags(full_message)[:100]))
 
             for recipient in self.recipients.all():
@@ -1189,7 +1187,7 @@ class UpdateRecord(models.Model):
                         request.user = recipient.user.user
                         storage = default_storage(request)
                         storage._add(
-                            Message(messages.constants.INFO, "%s" % grittertext))
+                            Message(messages.constants.INFO, "{0!s}".format(grittertext)))
                     except:
                         pass
 

--- a/treeio/core/rendering.py
+++ b/treeio/core/rendering.py
@@ -33,8 +33,7 @@ def _preprocess_context_html(context):
                 try:
                     # find popuplink fields
                     if field.widget.attrs and 'popuplink' in field.widget.attrs:
-                        field.help_text += '<a href="%s" field="id_%s" id="link-%s" class="inline-link add-link popup-link">%s</a>' % \
-                                           (field.widget.attrs['popuplink'], fname, fname, _("New"))
+                        field.help_text += '<a href="{0!s}" field="id_{1!s}" id="link-{2!s}" class="inline-link add-link popup-link">{3!s}</a>'.format(field.widget.attrs['popuplink'], fname, fname, _("New"))
                 except Exception:
                     pass
 
@@ -101,7 +100,7 @@ def render_to_ajax(template_name, context=None, context_instance=None):
                                     pass
                             message['title'] = unicode(update.author)
                         for obj in update.about.all():
-                            message['message'] = "(%s) %s:<br />%s" % (
+                            message['message'] = "({0!s}) {1!s}:<br />{2!s}".format(
                                 obj.get_human_type(), unicode(obj), message['message'])
                         notifications.append(message)
                     except:
@@ -171,8 +170,7 @@ def render_to_response(template_name, context=None, context_instance=None, respo
         f.close()
 
         wkpath = getattr(settings, 'WKPATH', './bin/wkhtmltopdf-i386')
-        x = subprocess.Popen("%s --print-media-type --orientation %s --page-size %s %s %s" %
-                             (wkpath,
+        x = subprocess.Popen("{0!s} --print-media-type --orientation {1!s} --page-size {2!s} {3!s} {4!s}".format(wkpath,
                               orientation,
                               page_size,
                               source,

--- a/treeio/core/sanitizer.py
+++ b/treeio/core/sanitizer.py
@@ -208,13 +208,13 @@ class HTMLSanitizerMixin(object):
                     token["name"] = "toberemoved"
 
                     if token_type == tokenTypes["EndTag"]:
-                        token["data"] = "</%s>" % token["name"]
+                        token["data"] = "</{0!s}>".format(token["name"])
                     elif token["data"]:
-                        attrs = ''.join([' %s="%s"' % (k, escape(v))
+                        attrs = ''.join([' {0!s}="{1!s}"'.format(k, escape(v))
                                         for k, v in token["data"]])
-                        token["data"] = "<%s%s>" % (token["name"], attrs)
+                        token["data"] = "<{0!s}{1!s}>".format(token["name"], attrs)
                     else:
-                        token["data"] = "<%s>" % token["name"]
+                        token["data"] = "<{0!s}>".format(token["name"])
                     if token.get("selfClosing"):
                         token["data"] = token["data"][:-1] + "/>"
 

--- a/treeio/core/search/dbsearch.py
+++ b/treeio/core/search/dbsearch.py
@@ -9,7 +9,7 @@ for model in get_models():
             if isinstance(field, CharField) or isinstance(field, TextField):
                 if 'password' not in field.name and 'object_name' not in field.name and 'object_type' not in field.name \
                         and 'nuvius' not in field.name:
-                    params.append('%s__%s' % (model._meta.module_name, field.name))
+                    params.append('{0!s}__{1!s}'.format(model._meta.module_name, field.name))
 
 
 def search(term):
@@ -21,7 +21,7 @@ def search(term):
         attr = 'icontains'
         term = term[1:]
     for param in params:
-        kwargs = {'%s__%s' % (param, attr): term}
+        kwargs = {'{0!s}__{1!s}'.format(param, attr): term}
         # query_dict[param] = term
         query = query | Q(**kwargs)
 

--- a/treeio/core/search/views.py
+++ b/treeio/core/search/views.py
@@ -54,7 +54,7 @@ def search_query(request, response_format='html'):
             elif search_engine == 'db':
                 objects = dbsearch.search(query)
             else:
-                raise RuntimeError('Unknown Search engine: %s' % search_engine)
+                raise RuntimeError('Unknown Search engine: {0!s}'.format(search_engine))
 
     return render_to_response('core/search/query_view',
                               {'query': query, 'objects': objects},

--- a/treeio/core/templatetags/modules.py
+++ b/treeio/core/templatetags/modules.py
@@ -222,7 +222,7 @@ def htsort(context, objects):
         if field_name in fields:
             field = objects.model._meta.get_field(field_name)
             if isinstance(field, models.ManyToManyField):
-                agg_field = agg_arg = str('sorting_%s' % field_name)
+                agg_field = agg_arg = str('sorting_{0!s}'.format(field_name))
                 if arg[0] == '-':
                     agg_arg = '-' + agg_arg
                 kwargs = {agg_field: models.Count(field_name)}
@@ -244,7 +244,7 @@ def htsortlink(context, field_name):
     request = context['request']
 
     sort_value = field_name
-    url = u"%s?" % (request.path)
+    url = u"{0!s}?".format((request.path))
     if request.GET:
         for arg in request.GET:
             values = request.GET.getlist(arg)
@@ -252,10 +252,10 @@ def htsortlink(context, field_name):
                 svalue = value.lstrip('-')
                 if arg == 'sorting' and svalue == field_name:
                     if value[0] != '-':
-                        sort_value = u'-%s' % sort_value
+                        sort_value = u'-{0!s}'.format(sort_value)
                 else:
                     url += unicode(arg) + "=" + value + "&"
-    url += "sorting=%s" % sort_value
+    url += "sorting={0!s}".format(sort_value)
 
     return url
 

--- a/treeio/core/views.py
+++ b/treeio/core/views.py
@@ -209,7 +209,7 @@ def ajax_popup(request, popup_id='', url='/'):
     response = None
     if active:
         if not request.user.profile.has_permission(active):
-            response = user_denied(request, "You do not have access to the %s module" % unicode(active),
+            response = user_denied(request, "You do not have access to the {0!s} module".format(unicode(active)),
                                    response_format='ajax')
 
     if not response:
@@ -593,5 +593,5 @@ def attachment_download(request, attachment_id):
 
     response = HttpResponse(data, content_type=attachment.mimetype)
     response[
-        'Content-Disposition'] = 'filename="%s"' % smart_unicode(attachment.filename)
+        'Content-Disposition'] = 'filename="{0!s}"'.format(smart_unicode(attachment.filename))
     return response

--- a/treeio/documents/files.py
+++ b/treeio/documents/files.py
@@ -15,5 +15,5 @@ class FileStorage(FileSystemStorage):
             path = safe_join(getattr(settings, 'MEDIA_ROOT'), name)
         except ValueError:
             raise SuspiciousOperation(
-                "Attempted access to '%s' denied." % name)
+                "Attempted access to '{0!s}' denied.".format(name))
         return os.path.normpath(path)

--- a/treeio/documents/views.py
+++ b/treeio/documents/views.py
@@ -625,7 +625,7 @@ def file_view(request, file_id, response_format='html'):
 
         response = HttpResponse(data, content_type='application/x-download')
         response[
-            'Content-Disposition'] = 'attachment; filename="%s"' % smart_str(file.content)
+            'Content-Disposition'] = 'attachment; filename="{0!s}"'.format(smart_str(file.content))
         return response
 
     context = _get_default_context(request)

--- a/treeio/events/rendering.py
+++ b/treeio/events/rendering.py
@@ -240,7 +240,7 @@ class EventCollection:
                             else:
                                 duration = duration - hour
                         height = duration * float(40) - 5
-                    style = "width: %.2f%%; height: %dpx; margin-left: %.2f%%" % (
+                    style = "width: {0:.2f}%; height: {1:d}px; margin-left: {2:.2f}%".format(
                         width, height, margin)
                     output += event.render_for_datehour(date,
                                                         hour, css_class, style)

--- a/treeio/events/views.py
+++ b/treeio/events/views.py
@@ -386,15 +386,15 @@ PRODID:-//PYVOBJECT//NONSGML Version 1//EN
     for event in events:
         vevent += "BEGIN:VEVENT\n"
         if event.start:
-            vevent += "DTSTART;VALUE=DATE:%s\n" % str(
-                (datetime.strptime(str(event.start)[0:10], '%Y-%m-%d')))[0:10].replace("-", "")
-        vevent += "DTEND;VALUE=DATE:%s\n" % str(
-            (datetime.strptime(str(event.end)[0:10], '%Y-%m-%d')))[0:10].replace("-", "")
+            vevent += "DTSTART;VALUE=DATE:{0!s}\n".format(str(
+                (datetime.strptime(str(event.start)[0:10], '%Y-%m-%d')))[0:10].replace("-", ""))
+        vevent += "DTEND;VALUE=DATE:{0!s}\n".format(str(
+            (datetime.strptime(str(event.end)[0:10], '%Y-%m-%d')))[0:10].replace("-", ""))
         if not event.details:
-            vevent += "SUMMARY:%s\n" % strip_tags(event.name)
+            vevent += "SUMMARY:{0!s}\n".format(strip_tags(event.name))
         else:
-            vevent += "SUMMARY:%s\n" % strip_tags(event.details)
-        vevent += "UID:%s\n" % (event.name)
+            vevent += "SUMMARY:{0!s}\n".format(strip_tags(event.details))
+        vevent += "UID:{0!s}\n".format((event.name))
         vevent += "END:VEVENT\n"
 
     icalstream += vevent

--- a/treeio/finance/csvapi.py
+++ b/treeio/finance/csvapi.py
@@ -17,7 +17,7 @@ class ProcessTransactions(object):
 
         response = HttpResponse(content_type='text/csv')
         response[
-            'Content-Disposition'] = 'attachment; filename=Transactions_%s.csv' % datetime.date.today().isoformat()
+            'Content-Disposition'] = 'attachment; filename=Transactions_{0!s}.csv'.format(datetime.date.today().isoformat())
 
         writer = csv.writer(response)
         headers = ['name', 'source', 'target', 'liability',

--- a/treeio/finance/models.py
+++ b/treeio/finance/models.py
@@ -36,9 +36,9 @@ class Currency(Object):
     def __unicode__(self):
         # return self.code
         if self.symbol:
-            return "%s    %s" % (self.symbol, self.name)
+            return "{0!s}    {1!s}".format(self.symbol, self.name)
         else:
-            return "%s  %s" % (self.code, self.name)
+            return "{0!s}  {1!s}".format(self.code, self.name)
 
     def save(self, **kwargs):
         try:

--- a/treeio/identities/csvapi.py
+++ b/treeio/identities/csvapi.py
@@ -67,7 +67,7 @@ class ProcessContacts(object):
         if url:
             if '://' not in url:
                 # If no URL scheme given, assume http://
-                url = u'http://%s' % url
+                url = u'http://{0!s}'.format(url)
             url_fields = list(urlparse.urlsplit(url))
             if not url_fields[2]:
                 # the path portion may need to be added before query params

--- a/treeio/identities/identicon.py
+++ b/treeio/identities/identicon.py
@@ -43,7 +43,7 @@ class Matrix2D(list):
             self[i] = 1.
 
     def __str__(self):
-        return '[%s]' % ', '.join('%3.2f' % v for v in self)
+        return '[{0!s}]'.format(', '.join('{0:3.2f}'.format(v) for v in self))
 
     def __mul__(self, other):
         r = []
@@ -254,4 +254,4 @@ if __name__ == '__main__':
             code = int(code)
 
         icon = render_identicon(code, 24)
-        icon.save('%08x.png' % code, 'PNG')
+        icon.save('{0:08x}.png'.format(code), 'PNG')

--- a/treeio/messaging/emails.py
+++ b/treeio/messaging/emails.py
@@ -113,7 +113,7 @@ class EmailMessage(Thread):
         "Process email"
         message = self.message
         if message.reply_to:
-            subject = "Re: %s" % message.reply_to.title
+            subject = "Re: {0!s}".format(message.reply_to.title)
         else:
             subject = message.title
         body = strip_tags(message.body)

--- a/treeio/projects/views.py
+++ b/treeio/projects/views.py
@@ -1252,7 +1252,7 @@ def gantt_view(request, project_id, response_format='html'):
         for task in tasks:
             tlabel = (
                 task.name[:30] + '..') if len(task.name) > 30 else task.name
-            tn = '<a href="%s" class="popup-link">%s</a>' % (
+            tn = '<a href="{0!s}" class="popup-link">{1!s}</a>'.format(
                 reverse('projects_task_view', args=[task.id]), tlabel)
             series.append({'id': task.id,
                            'name': tn,
@@ -1261,7 +1261,7 @@ def gantt_view(request, project_id, response_format='html'):
                            'end': task.end_date.date().isoformat()})
         mlabel = (
             milestone.name[:30] + '..') if len(milestone.name) > 30 else milestone.name
-        mn = '<a href="%s" class="popup-link projects-milestone">%s</a>' % (
+        mn = '<a href="{0!s}" class="popup-link projects-milestone">{1!s}</a>'.format(
             reverse('projects_milestone_view', args=[milestone.id]), mlabel)
         a = {'id': milestone.id, 'name': mn, 'label': mlabel}
         if series:
@@ -1279,7 +1279,7 @@ def gantt_view(request, project_id, response_format='html'):
     series = []
     for task in unclassified:
         tlabel = (task.name[:30] + '..') if len(task.name) > 30 else task.name
-        tn = '<a href="%s" class="popup-link">%s</a>' % (
+        tn = '<a href="{0!s}" class="popup-link">{1!s}</a>'.format(
             reverse('projects_task_view', args=[task.id]), tlabel)
         series.append({'id': task.id,
                        'name': tn,

--- a/treeio/reports/forms.py
+++ b/treeio/reports/forms.py
@@ -268,7 +268,7 @@ class FilterForm(forms.Form):
                 display_operand = dc
                 break
 
-        display = "%s %s %s" % (
+        display = "{0!s} {1!s} {2!s}".format(
             field.get_human_name(), display_operand, unicode(display_choice))
         field.filters.append({'choice': c,
                               'operand': self.data['operand'],

--- a/treeio/reports/templatetags/reports.py
+++ b/treeio/reports/templatetags/reports.py
@@ -105,7 +105,7 @@ def display_chart(context, chart, skip_group=False):
         # chart_dict['xAxis']['gridLineWidth']= 1,
         chart_dict['series'] = [{'name': model.name.split('.')[-1], 'data': []}]
         for x in set(l):
-            chart_dict['series'][0]['data'].append(('%s UTC' % x, l.count(x)))
+            chart_dict['series'][0]['data'].append(('{0!s} UTC'.format(x), l.count(x)))
 
     else:
         l = [unicode(obj.get_field_value(field_name)) for obj in objs]
@@ -222,7 +222,7 @@ register.object(is_field_number)
 @contextfunction
 def select_for_aggregation(context, field_name, value):
     select_str = '<select type="select" name="aggregation-%(field_name)s"><option></option>%(options)s</select>'
-    options = ''.join(['<option value="%s"%s>%s</option>' % (name, ' selected' if value == name else '',
+    options = ''.join(['<option value="{0!s}"{1!s}>{2!s}</option>'.format(name, ' selected' if value == name else '',
                                                              _(func['description'])) for name, func in
                        aggregate_functions.items()])
     return Markup(select_str % {'field_name': field_name,

--- a/treeio/reports/views.py
+++ b/treeio/reports/views.py
@@ -61,8 +61,7 @@ def _get_objects():
     object_types = Object.objects.all().values(
         'object_type').distinct().order_by('object_type')
     # TODO: filter these
-    object_names = ["(%s)  %s" %
-                    (object_types[i]['object_type'].split('.')[1].title(),
+    object_names = ["({0!s})  {1!s}".format(object_types[i]['object_type'].split('.')[1].title(),
                      Object.objects.filter(
                          object_type=object_types[i]['object_type'])
                      .order_by()[0].get_human_type())
@@ -435,7 +434,7 @@ def report_add(request, response_format='html'):
         model = Model(full_object, fields)
 
         report = Report()
-        report.name = "Untitled %s Report" % (obj._meta.object_name)
+        report.name = "Untitled {0!s} Report".format((obj._meta.object_name))
         report.model = dumps(model)
         report.creator = request.user.profile
         report.save()
@@ -460,7 +459,7 @@ def report_add(request, response_format='html'):
         human_type = Object.objects.filter(
             object_type=object_type['object_type'])[0].get_human_type()
 
-        object_names.append("%s: %s" % (module_name, human_type))
+        object_names.append("{0!s}: {1!s}".format(module_name, human_type))
 
     form = ObjChoiceForm(request.user, object_types=object_types, object_names=object_names)
 

--- a/treeio/sales/models.py
+++ b/treeio/sales/models.py
@@ -234,7 +234,7 @@ class SaleOrder(Object):
                 models.Max('id'))['id__max'] + 1
         except:
             next_ref = 1
-        full_ref = '%.5d/%s' % (next_ref, str(str(ttime() * 10)[8:-2]))
+        full_ref = '{0:.5d}/{1!s}'.format(next_ref, str(str(ttime() * 10)[8:-2]))
         return full_ref
 
     def save(self, *args, **kwargs):

--- a/treeio/services/emails.py
+++ b/treeio/services/emails.py
@@ -69,8 +69,8 @@ class EmailMessage(Thread):
                     # don't send email to yourself
                     if message.reply_to.author != message.author:
 
-                        fromaddr = "%s" % original_author
-                        toaddr = "%s" % reply_author
+                        fromaddr = "{0!s}".format(original_author)
+                        toaddr = "{0!s}".format(reply_author)
 
                         login = message.stream.outgoing_server_username
                         password = message.stream.outgoing_password
@@ -79,7 +79,7 @@ class EmailMessage(Thread):
                         body += _('Your message is received and a ticket is created, ticket reference is [%s]') % (
                             self.ticket_record.ticket.reference)
 
-                        subject = "[%s] %s\r\n\r\n" % (
+                        subject = "[{0!s}] {1!s}\r\n\r\n".format(
                             self.ticket_record.ticket.reference, self.ticket_record.ticket.message.title)
 
                         BaseEmail(message.stream.outgoing_server_name,

--- a/treeio/services/forms.py
+++ b/treeio/services/forms.py
@@ -332,7 +332,7 @@ class TicketRecordForm(forms.ModelForm):
                     reply.reply_to = ticket.message
                 else:
                     reply.stream = ticket.queue.message_stream if ticket.queue else None
-                    reply.title = "[#%s] %s" % (ticket.reference, ticket.name)
+                    reply.title = "[#{0!s}] {1!s}".format(ticket.reference, ticket.name)
                 reply.save()
                 if not ticket.message:
                     ticket.message = reply

--- a/treeio/services/models.py
+++ b/treeio/services/models.py
@@ -270,7 +270,7 @@ def email_caller_on_new_ticket(sender, instance, created, **kwargs):
                     else:
                         instance.reference = str(instance.id)
                     instance.save()
-                subject = "[#%s] %s" % (instance.reference, instance.name)
+                subject = "[#{0!s}] {1!s}".format(instance.reference, instance.name)
 
                 # Construct context and render to html, body
                 context = {'ticket': instance}

--- a/treeio_project/settings.py
+++ b/treeio_project/settings.py
@@ -48,7 +48,7 @@ if TESTING:
     elif test_db == 'mssql':
         DATABASES = {'default': {
             'ENGINE': 'sqlserver',
-            'NAME': 'anaf_%s' % os.environ.get('MC'),
+            'NAME': 'anaf_{0!s}'.format(os.environ.get('MC')),
             'USER': 'anaf',
             'PASSWORD': 'anaf',
             'HOST': '10.0.0.9',


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tovmeod:anaf?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tovmeod:anaf?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)